### PR TITLE
react-router@4 사용

### DIFF
--- a/actions/dispatchers/profileDispatchers.js
+++ b/actions/dispatchers/profileDispatchers.js
@@ -1,4 +1,5 @@
-import {browserHistory} from 'react-router';
+import {goBack} from 'react-router-redux';
+
 import {DataCon, Url} from '../../utils';
 import * as types from '../actionTypes';
 import {loadProfileTag, updateFollowingList, alertModal} from './';
@@ -31,7 +32,7 @@ export function loadProfileDetail(dispatch, id) {
       type: types.ERR_PROFILE_DETAIL
     });
     alertModal(dispatch, '알림', '존재하지 않는 프로필입니다.', () => {
-      browserHistory.goBack();
+      dispatch(goBack());
     });
   });
 }

--- a/actions/dispatchers/tagDispatchers.js
+++ b/actions/dispatchers/tagDispatchers.js
@@ -1,4 +1,5 @@
-import {browserHistory} from 'react-router';
+import {goBack} from 'react-router-redux';
+
 import {DataCon, Url} from '../../utils';
 import * as types from '../actionTypes';
 import {alertModal} from './modalDispatchers';
@@ -84,12 +85,12 @@ export function loadTagInformation(dispatch, tagName) {
         tagInformation: null
       });
       alertModal(dispatch, '알림', '존재하지 않는 태그입니다.', () => {
-        browserHistory.goBack();
+        dispatch(goBack());
       });
     });
   } else {
     alertModal(dispatch, '알림', '정상적이지 않은 접근입니다.', () => {
-      browserHistory.goBack();
+      dispatch(goBack());
     });
   }
 }

--- a/app.js
+++ b/app.js
@@ -3,9 +3,11 @@ import 'core-js/shim';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Router, Route, browserHistory, IndexRoute} from 'react-router';
-import {createStore, combineReducers} from 'redux';
+import {Route, Switch} from 'react-router';
+import {createStore, combineReducers, applyMiddleware} from 'redux';
 import {Provider} from 'react-redux';
+import {ConnectedRouter, routerReducer, routerMiddleware} from 'react-router-redux';
+import createHistory from 'history/createBrowserHistory';
 
 import './stylesheets/reset.css';
 import './stylesheets/common.styl';
@@ -34,32 +36,55 @@ import {
 import reducers from './reducers';
 
 const rootElement = document.getElementById('content');
+const history = createHistory();
+const middleware = routerMiddleware(history);
 
-const store = createStore(combineReducers(reducers));
+const store = createStore(
+  combineReducers({...reducers, routerReducer}),
+  applyMiddleware(middleware)
+);
+
+const ProfileIdRoute = ({match}) => (
+  <Switch>
+    <Route path={`${match.url}/admin`} component={ProfileAdmin}/>
+    <Route path={`${match.url}/transfer_admin`} component={ProfileAdminTransfer}/>
+    <Route path={`${match.url}/write`} component={ArticleWrite}/>
+  </Switch>
+);
+const ProfileRoute = ({match}) => (
+  <Switch>
+    <Route exact path={`${match.url}`} component={ProfileList}/>
+    <Route path={`${match.url}/new`} component={ProfileMake}/>
+    <Route path={`${match.url}/:id`} component={ProfileIdRoute}/>
+  </Switch>
+);
+const MenuRoute = () => (
+  <Menu>
+    <Switch>
+      <Route exact path="/" component={Main}/>
+      <Route path="/message" component={Message}/>
+      <Route path="/others" component={Others}/>
+      <Route path="/profiles" component={ProfileRoute}/>
+      <Route path="/search" component={SearchResult}/>
+      <Route path="/settings" component={Settings}/>
+      <Route path="/tags" component={TagInfo}/>
+      <Route path="/activities" component={Activity}/>
+      <Route path="/:articleId/edit" component={ArticleEdit}/>
+      <Route exact path="/:id" component={ClassManager}/>
+    </Switch>
+  </Menu>
+);
 
 ReactDOM.render(
   <Provider store={store}>
     <TimeManager>
-      <Router history={browserHistory}>
-        <Route path="/login" component={Login}/>
-        <Route path="/sign-up" component={SignUp}/>
-        <Route path="/" component={Menu} pollInterval={2000}>
-          <IndexRoute component={Main} pollInterval={2000}/>
-          <Route path="message" component={Message}/>
-          <Route path="others" component={Others}/>
-          <Route path="profiles" component={ProfileList}/>
-          <Route path="profiles/new" component={ProfileMake}/>
-          <Route path="profiles/:id/admin" component={ProfileAdmin}/>
-          <Route path="profiles/:id/transfer_admin" component={ProfileAdminTransfer}/>
-          <Route path="profiles/:id/write" component={ArticleWrite}/>
-          <Route path="search" component={SearchResult}/>
-          <Route path="settings" component={Settings}/>
-          <Route path="tags" component={TagInfo}/>
-          <Route path="activities" component={Activity}/>
-          <Route path=":id" component={ClassManager}/>
-          <Route path=":articleId/edit" component={ArticleEdit}/>
-        </Route>
-      </Router>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route path="/login" component={Login}/>
+          <Route path="/sign-up" component={SignUp}/>
+          <Route path="/" component={MenuRoute}/>
+        </Switch>
+      </ConnectedRouter>
     </TimeManager>
   </Provider>,
   rootElement

--- a/components/Activity.js
+++ b/components/Activity.js
@@ -1,11 +1,11 @@
 import React from 'react';
-
+import queryString from 'query-string';
 import ActivityList from './ActivityList';
 
 const Activity = React.createClass({
 
   render() {
-    const {query} = this.props.location;
+    const query = queryString.parse(this.props.location.search);
     return (
       <div>
         <ActivityList query={query}/>

--- a/components/ActivityList/ActivityFilter.js
+++ b/components/ActivityList/ActivityFilter.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {connect} from 'react-redux';
+import {push} from 'react-router-redux';
 import classnames from 'classnames';
 
 import {DataCon, Url, genRefCallback} from '../../utils';
@@ -292,12 +293,7 @@ const ActivityFilter = React.createClass({
     params.filterType = this.state.selectedType.type;
     params.filterAction = this.state.selectedAction;
     params.profileId = this.state.profileId;
-    const paramsString = Object.keys(params).filter(key => {
-      return params[key] !== undefined && params[key] !== null;
-    }).map(key => {
-      return `${key}=${params[key]}`;
-    }).join('&');
-    browserHistory.push(`/activities?${paramsString}`);
+    this.props.pushHistory(params);
   },
 
   render() {
@@ -381,4 +377,17 @@ const ActivityFilter = React.createClass({
   }
 });
 
-export default ActivityFilter;
+const mapDispatchToProps = function (dispatch) {
+  return {
+    pushHistory: params => {
+      const paramsString = Object.entries(params).filter(([key, value]) => {
+        return typeof key === 'string' && value != null; // catches both undefined and null
+      }).map(([key, value]) => {
+        return `${key}=${value}`;
+      }).join('&');
+      dispatch(push(`/activities?${paramsString}`));
+    }
+  };
+};
+
+export default connect(null, mapDispatchToProps)(ActivityFilter);

--- a/components/ActivityList/ActivityListItem.js
+++ b/components/ActivityList/ActivityListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import moment from 'moment';
 
 const messages = {

--- a/components/ActivityList/ActivityPageNavigation.js
+++ b/components/ActivityList/ActivityPageNavigation.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 const ActivityPageNavigation = React.createClass({
 

--- a/components/ArticleEdit.js
+++ b/components/ArticleEdit.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
 import {DataCon, Url, connectModals} from '../utils';
 import Editor from './Editor';
 
@@ -9,7 +8,7 @@ import '../stylesheets/article-write.styl';
 
 const ArticleEdit = React.createClass({
   loadArticleFromServer() {
-    const {articleId} = this.props.params;
+    const {articleId} = this.props.match.params;
     const url = Url.getUrl(`/articles/${articleId}`);
     DataCon.loadDataFromServer(Url.getUrl('/users/me')).then(data => {
       return data.id;
@@ -50,7 +49,7 @@ const ArticleEdit = React.createClass({
   },
 
   submitEdit(data) {
-    const {articleId} = this.props.params;
+    const {articleId} = this.props.match.params;
     const url = Url.getUrl(`/articles/${articleId}`);
     DataCon.postFormDataToServer(url, 'PUT', data)
       .catch(console.error);
@@ -124,7 +123,7 @@ const ArticleEdit = React.createClass({
       files
     });
     this.setState({title: '', content: '', renderingMode: 'text'});
-    browserHistory.goBack();
+    this.props.history.goBack();
   },
 
   render() {
@@ -135,7 +134,7 @@ const ArticleEdit = React.createClass({
 
     if (this.state.valid === false) {
       this.props.alertModal('알림', '권한이 없습니다.', () => {
-        browserHistory.goBack();
+        this.props.history.goBack();
       });
       return null;
     }

--- a/components/ArticleItem/ArticleItem.js
+++ b/components/ArticleItem/ArticleItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import {connect} from 'react-redux';
-import {Link, browserHistory} from 'react-router';
+import {Link} from 'react-router-dom';
 
 import Realtime from '../Realtime';
 import {Url, DataCon} from '../../utils';
@@ -14,7 +14,7 @@ const ArticleItem = React.createClass({
     const url = Url.getUrl(`/articles/${articleId}`);
     DataCon.postDataToServer(url, 'DELETE')
       .then(() => {
-        browserHistory.goBack();
+        this.props.history.goBack();
       }).catch(console.error);
   },
 

--- a/components/ClassManager.js
+++ b/components/ClassManager.js
@@ -5,7 +5,7 @@ import Article from './Article';
 const re = /^\d+$/;
 const ClassManager = React.createClass({
   render() {
-    const {id} = this.props.params;
+    const {id} = this.props.match.params;
     if (re.test(id)) {
       return <Article id={id}/>;
     }

--- a/components/FeedList/FeedArticle.js
+++ b/components/FeedList/FeedArticle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import Measure from 'react-measure';
 import moment from 'moment';
 import classnames from 'classnames';

--- a/components/Menu/FollowingProfileList.js
+++ b/components/Menu/FollowingProfileList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
 
 const FollowingProfileList = React.createClass({

--- a/components/Menu/SideMenu.js
+++ b/components/Menu/SideMenu.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
 
 import {UserLevel} from '../../utils';

--- a/components/Menu/TopMenu.js
+++ b/components/Menu/TopMenu.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
 
 import {UserLevel} from '../../utils';

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
 
 import {updateFollowingList, loadProfileDetail, updateFollowingState} from '../actions/dispatchers';

--- a/components/ProfileAdmin.js
+++ b/components/ProfileAdmin.js
@@ -8,17 +8,17 @@ import '../stylesheets/profile.styl';
 
 const ProfileAdmin = React.createClass({
   componentDidMount() {
-    this.props.loadProfileDetail(this.props.params.id);
+    this.props.loadProfileDetail(this.props.match.params.id);
   },
 
   componentWillReceiveProps(props) {
-    if (this.props.params.id !== props.params.id) {
-      this.props.loadProfileDetail(props.params.id);
+    if (this.props.match.params.id !== props.match.params.id) {
+      this.props.loadProfileDetail(props.match.params.id);
     }
   },
 
   render() {
-    const {id} = this.props.params;
+    const {id} = this.props.match.params;
     const {name, description, renderingMode, admin, userId} = this.props;
     const mine = admin && (admin.id === userId);
     return (

--- a/components/ProfileAdminTransfer.js
+++ b/components/ProfileAdminTransfer.js
@@ -4,7 +4,7 @@ import {ProfileAdminTransferBox} from './boxes';
 
 const ProfileAdminTransfer = React.createClass({
   render() {
-    return <ProfileAdminTransferBox id={this.props.params.id}/>;
+    return <ProfileAdminTransferBox id={this.props.match.params.id}/>;
   }
 });
 

--- a/components/ProfileList/ProfileList.js
+++ b/components/ProfileList/ProfileList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
 
 import {loadAllProfiles} from '../../actions/dispatchers';

--- a/components/SearchResultContainer/OverallSearchResultView.js
+++ b/components/SearchResultContainer/OverallSearchResultView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 import {ArticleSearchResult, CommentSearchResult, ProfileSearchResult, TagSearchResult} from './SearchResultItems';
 

--- a/components/SearchResultContainer/SearchResultContainer.js
+++ b/components/SearchResultContainer/SearchResultContainer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import isEqual from 'deep-equal';
+import queryString from 'query-string';
 
 import {loadSearchResult} from '../../actions/dispatchers';
 import SearchResultView from './SearchResultView';
@@ -11,19 +12,21 @@ const SearchResultContainer = React.createClass({
   },
 
   componentDidMount() {
-    this.loadSearchResult(this.props.location.query);
+    this.loadSearchResult(queryString.parse(this.props.location.search));
   },
 
   componentWillReceiveProps(props) {
-    if (!isEqual(props.location.query, this.props.location.query)) {
+    const oldQ = queryString.parse(this.props.location.search);
+    const newQ = queryString.parse(props.location.search);
+    if (!isEqual(oldQ, newQ)) {
       window.scrollTo(0, 0);
-      this.loadSearchResult(props.location.query);
+      this.loadSearchResult(newQ);
     }
   },
 
   render() {
     const {result} = this.props;
-    const {category, query, page} = this.props.location.query;
+    const {category, query, page} = queryString.parse(this.props.location.search);
     return <SearchResultView category={category} query={query} page={page} result={result}/>;
   }
 });

--- a/components/SearchResultContainer/SearchResultItems.js
+++ b/components/SearchResultContainer/SearchResultItems.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
+import queryString from 'query-string';
 import moment from 'moment';
 
 import Realtime from '../Realtime';
@@ -58,7 +59,7 @@ export const TagSearchResult = React.createClass({
     const {tag} = this.props.tag;
     return (
       <article className="search-item tag-search-item">
-        <Link to={{pathname: '/tags', query: {tag}}}>{tag}</Link>
+        <Link to={{pathname: '/tags', search: '?' + queryString.stringify({tag})}}>{tag}</Link>
       </article>
     );
   }

--- a/components/SearchResultContainer/SearchResultLinks.js
+++ b/components/SearchResultContainer/SearchResultLinks.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 const SearchResultLinks = React.createClass({
   renderLink(category, query, page, ch = page) {

--- a/components/SignUp.js
+++ b/components/SignUp.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
 import {connect} from 'react-redux';
 
 import {DataCon, Url, genRefCallback, connectModals} from '../utils';
@@ -54,7 +53,7 @@ const SignUpForm = connectModals(React.createClass({
     DataCon.postDataToServer(Url.getUrl('/users/sign_up'), 'POST', values)
       .then(() => {
         this.props.alertModal('알림', '가입에 성공하였습니다.');
-        browserHistory.push('/login');
+        this.props.history.push('/login');
       }).catch(() => {
         // TODO: 에러 발생 조건에 뭐가 있는지 확인하기
         this.props.alertModal('알림', '가입에 실패했습니다.');

--- a/components/TagCloud/TagCloud.js
+++ b/components/TagCloud/TagCloud.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import {connect} from 'react-redux';
+import queryString from 'query-string';
 
 import {UserLevel} from '../../utils';
 
@@ -11,7 +12,9 @@ const TagCloud = React.createClass({
         case UserLevel.REGULAR:
           return (
             <li className="tag-cloud-tag-item" key={tag.tag}>
-              <Link to={{pathname: '/tags', query: {tag: tag.tag}}}>{tag.tag}</Link>
+              <Link to={{pathname: '/tags', search: '?' + queryString.stringify({tag: tag.tag})}}>
+                {tag.tag}
+              </Link>
             </li>
           );
         default:

--- a/components/TagInfo/TagViewWrapper.js
+++ b/components/TagInfo/TagViewWrapper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 import moment from 'moment';
 
 import '../../stylesheets/taginfo.styl';

--- a/components/TagInfo/index.js
+++ b/components/TagInfo/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import queryString from 'query-string';
 
 import TagContainer from './TagContainer';
 
 const TagInfo = React.createClass({
   render() {
-    return <TagContainer tagName={this.props.location.query.tag}/>;
+    return <TagContainer tagName={queryString.parse(this.props.location.search).tag}/>;
   }
 });
 

--- a/components/boxes/CommentBox/CommentItem.js
+++ b/components/boxes/CommentBox/CommentItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 import Realtime from '../../Realtime';
 import {connectModals} from '../../../utils';

--- a/components/boxes/DelEditBox.js
+++ b/components/boxes/DelEditBox.js
@@ -1,15 +1,12 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {connect} from 'react-redux';
+import {push} from 'react-router-redux';
 
 import {connectModals} from '../../utils';
 
 const DelEditBox = React.createClass({
-  updateArticle(articleId) {
-    browserHistory.push(`/${articleId}/edit`);
-  },
-
   handleArticleUpdate() {
-    this.updateArticle(this.props.articleId);
+    this.props.updateArticle(this.props.articleId);
   },
 
   handleArticleDelete() {
@@ -30,4 +27,10 @@ const DelEditBox = React.createClass({
   }
 });
 
-export default connectModals(DelEditBox);
+const mapDispatchToProps = function (dispatch) {
+  return {
+    updateArticle: articleId => dispatch(push(`/${articleId}/edit`))
+  };
+};
+
+export default connectModals(connect(null, mapDispatchToProps)(DelEditBox));

--- a/components/boxes/ProfileBox/ProfileAdminTransferBox.js
+++ b/components/boxes/ProfileBox/ProfileAdminTransferBox.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 import {connectModals} from '../../../utils';
 import {loadProfileDetail, changeAdmin} from '../../../actions/dispatchers';

--- a/components/boxes/ProfileBox/ProfileAdminTransferContainer.js
+++ b/components/boxes/ProfileBox/ProfileAdminTransferContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
 
 /*
  * props

--- a/components/boxes/ProfileBox/ProfileEditBoxContainer.js
+++ b/components/boxes/ProfileBox/ProfileEditBoxContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {browserHistory} from 'react-router';
+import {push} from 'react-router-redux';
 import {DataCon, Url, connectModals} from '../../../utils';
 
 import {updateFollowingList, loadProfileDetail} from '../../../actions/dispatchers';
@@ -16,20 +16,12 @@ import ProfileEditBox from './ProfileEditBox';
  */
 
 const ProfileEditBoxContainer = React.createClass({
-  submitEdit(data) {
-    const url = Url.getUrl(`/profiles/${this.props.id}`);
-    DataCon.postDataToServer(url, 'PUT', data)
-      .then(() => this.props.updateFollowingList())
-      .then(() => this.props.loadProfileDetail(this.props.id));
-  },
-
   handleEdit(data) {
     if (data.name === '' || data.description === '') {
       this.props.alertModal('알림', '이름과 설명을 모두 입력해주세요.');
       return;
     }
-    this.submitEdit(data);
-    browserHistory.push(`/${this.props.id}`);
+    this.props.submitEdit(data, this.props.id);
   },
 
   render() {
@@ -47,7 +39,15 @@ const ProfileEditBoxContainer = React.createClass({
 const mapDispatchToProps = function (dispatch) {
   return {
     updateFollowingList: () => updateFollowingList(dispatch),
-    loadProfileDetail: id => loadProfileDetail(dispatch, id)
+    loadProfileDetail: id => loadProfileDetail(dispatch, id),
+    submitEdit: (data, id) => {
+      const url = Url.getUrl(`/profiles/${this.props.id}`);
+      DataCon.postDataToServer(url, 'PUT', data)
+        .then(() => this.props.updateFollowingList())
+        .then(() => this.props.loadProfileDetail(this.props.id))
+        .then(() => dispatch(push(`/${id}`)))
+        .catch(console.error);
+    }
   };
 };
 

--- a/components/boxes/SearchBox/SearchForm.js
+++ b/components/boxes/SearchBox/SearchForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {connect} from 'react-redux';
+import {push} from 'react-router-redux';
 
 import {genRefCallback, connectModals} from '../../../utils';
 
@@ -19,7 +20,7 @@ const SearchForm = React.createClass({
       this.props.alertModal('알림', '두 글자 이상 입력해주세요');
       return;
     }
-    browserHistory.push(`/search?query=${query}`);
+    this.props.search(query);
   },
 
   render() {
@@ -33,4 +34,10 @@ const SearchForm = React.createClass({
   }
 });
 
-export default connectModals(SearchForm);
+const mapDispatchToProps = function (dispatch) {
+  return {
+    search: query => dispatch(push(`/search?query=${query}`))
+  };
+};
+
+export default connectModals(connect(null, mapDispatchToProps)(SearchForm));

--- a/components/boxes/TagBox/TagItem.js
+++ b/components/boxes/TagBox/TagItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Link} from 'react-router';
+import {Link} from 'react-router-dom';
+import queryString from 'query-string';
 
 const TagItem = React.createClass({
 
@@ -14,7 +15,12 @@ const TagItem = React.createClass({
 
   render() {
     const tagName = this.props.accessible ? (
-      <Link className="tag-item-name" to={{pathname: '/tags', query: {tag: this.props.tag.tag}}}>{this.props.tag.tag}</Link>
+      <Link
+        className="tag-item-name"
+        to={{pathname: '/tags', search: '?' + queryString.stringify({tag: this.props.tag.tag})}}
+        >
+        {this.props.tag.tag}
+      </Link>
     ) : (
       <span className="tag-item-name">{this.props.tag.tag}</span>
     );

--- a/package.json
+++ b/package.json
@@ -39,15 +39,19 @@
     "classnames": "^2.2.5",
     "core-js": "^2.4.1",
     "deep-equal": "^1.0.1",
+    "history": "^4.6.1",
     "immutable": "^3.8.1",
     "js-cookie": "^2.1.3",
     "moment": "^2.14.1",
+    "query-string": "^4.3.2",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-interval": "^1.3.3",
     "react-measure": "^1.4.5",
     "react-redux": "^4.4.5",
-    "react-router": "^2.7.0",
+    "react-router": "^4.0.0",
+    "react-router-dom": "^4.0.0",
+    "react-router-redux": "next",
     "redux": "^3.6.0",
     "simplemde": "^1.11.2",
     "whatwg-fetch": "^1.0.0"
@@ -69,7 +73,8 @@
       "react/forbid-component-props": "off",
       "react/no-danger": "off",
       "react/prop-types": "off",
-      "filenames/match-exported": "error"
+      "filenames/match-exported": "error",
+      "no-use-extend-native/no-use-extend-native": "off"
     },
     "plugins": [
       "filenames"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@ deep-assign@^1.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-deep-equal@^1.0.0, deep-equal@^1.0.1:
+deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -2362,20 +2362,21 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-history@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-2.1.2.tgz#4aa2de897a0e4867e4539843be6ecdb2986bfdec"
+history@^4.5.1, history@^4.6.0, history@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
   dependencies:
-    deep-equal "^1.0.0"
-    invariant "^2.0.0"
-    query-string "^3.0.0"
-    warning "^2.0.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.0.0"
+    value-equal "^0.2.0"
+    warning "^3.0.0"
 
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -2526,9 +2527,9 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.1.tgz#b097010547668c7e337028ebe816ebe36c8a8d54"
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -2732,6 +2733,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2770,6 +2775,10 @@ js-cookie@^2.1.3:
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
+
+js-tokens@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-types@^1.0.0:
   version "1.0.0"
@@ -3040,11 +3049,11 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
-    js-tokens "^2.0.0"
+    js-tokens "^3.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -3479,6 +3488,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.5.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -3857,15 +3872,16 @@ qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
-query-string@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-3.0.3.tgz#ae2e14b4d05071d4e9b9eb4873c35b0dcd42e638"
-  dependencies:
-    strict-uri-encode "^1.0.0"
-
 query-string@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.3.tgz#9f27273d207a25a8ee4c7b8c74dcd45d556db822"
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.2.tgz#ec0fd765f58a50031a3968c2431386f8947a5cdd"
   dependencies:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
@@ -3930,14 +3946,28 @@ react-redux@^4.4.5:
     lodash "^4.2.0"
     loose-envify "^1.1.0"
 
-react-router@^2.7.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-2.8.1.tgz#73e9491f6ceb316d0f779829081863e378ee4ed7"
+react-router-dom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0.tgz#4fa4418e14b8cfc5bcc0bdea0c4083fb8c2aef10"
   dependencies:
-    history "^2.1.2"
-    hoist-non-react-statics "^1.2.0"
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
+    history "^4.5.1"
+    react-router "^4.0.0"
+
+react-router-redux@next:
+  version "5.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.3.tgz#ecff3fb955dded28c2a23e57e244c58165d5bcc7"
+  dependencies:
+    history "^4.5.1"
+    react-router "^4.0.0"
+
+react-router@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0.tgz#6532075231f0bb5077c2005c1d417ad6165b3997"
+  dependencies:
+    history "^4.6.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.5.3"
     warning "^3.0.0"
 
 react@^15.3.1:
@@ -4174,6 +4204,10 @@ resolve-from@^1.0.0:
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve-pathname@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.0.2.tgz#e55c016eb2e9df1de98e85002282bfb38c630436"
 
 resolve@^1.1.6:
   version "1.1.7"
@@ -4793,6 +4827,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+value-equal@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.2.0.tgz#4f41c60a3fc011139a2ec3d3340a8998ae8b69c0"
+
 vary@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.0.tgz#e1e5affbbd16ae768dd2674394b9ad3022653140"
@@ -4812,12 +4850,6 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-warning@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-2.1.0.tgz#21220d9c63afc77a8c92111e011af705ce0c6901"
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
커밋을 도저히 쪼갤 수가 없어서 하나의 큰 커밋으로 푸시합니다.

## 주요 변화

* 이제 `props.location`에 `query`가 없습니다. 제가 `query-string` 패키지를 추가해 두었으니 `search`를 파싱해서 써야 합니다.
  * 비슷하게 `Link`에 `query`를 건넬 수 없습니다.
* `browserHistory`를 쓸 수 없습니다. 대신에 `react-router-redux`에서 `push`, `goBack` 등의 액션 생성 함수를 불러와서 직접 dispatch해야 합니다.
* `Route`가 제공하는 `params`는 `props.params`가 아니라 `props.match.params`에 있습니다.

## 세세한 변화
* `no-use-extend-native/no-use-extend-native`가 `Object.entries`를 인식하지 못했기 때문에 린터에서 제외했습니다.

## 앞으로 해야 할 일
* 라우터 구조를 갈아엎는 것도 생각해 봐야 합니다.

---

앞으로 코딩할 때 이 변화에 유의해서 해 주시고, **테스트는 꼼꼼하게 해 주세요!**