### PR TITLE
Authentication

### DIFF
--- a/components/Login.js
+++ b/components/Login.js
@@ -20,7 +20,7 @@ const Login = React.createClass({
             <LoginForm/>
             <section id="login-box-footer">
               <Link className="login-box-footer-link" to="/sign-up">가입 신청하기</Link>
-              <a className="login-box-footer-link" href="https://id.snucse.org/Authentication/FindAccountForm.aspx" target="_blank">비밀번호 찾기</a>
+              <a className="login-box-footer-link" href="https://id.snucse.org/Authentication/FindAccountForm.aspx" target="_blank" rel="noopener noreferrer">비밀번호 찾기</a>
             </section>
           </div>
         </div>

--- a/components/Login.js
+++ b/components/Login.js
@@ -20,6 +20,7 @@ const Login = React.createClass({
             <LoginForm/>
             <section id="login-box-footer">
               <Link className="login-box-footer-link" to="/sign-up">가입 신청하기</Link>
+              <a className="login-box-footer-link" href="https://id.snucse.org/Authentication/FindAccountForm.aspx" target="_blank">비밀번호 찾기</a>
             </section>
           </div>
         </div>

--- a/components/SignUp.js
+++ b/components/SignUp.js
@@ -27,7 +27,7 @@ const SignUp = React.createClass({
   }
 });
 
-const formNames = ['username', 'password', 'password2', 'name', 'birthday', 'bsNumber', 'phoneNumber', 'email'];
+const formNames = ['username', 'name', 'birthday', 'bsNumber', 'phoneNumber', 'email'];
 const usernameReg = /^[A-Za-z][A-Za-z0-9]*$/;
 const birthReg = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 const bsNumReg = /^[0-9]{4}-[0-9]{5}$/;
@@ -64,20 +64,6 @@ const SignUpForm = connectModals(React.createClass({
     if (!(usernameReg.test(values.username))) {
       this.props.alertModal('알림', '아이디는 영문자로 시작하며, 영문자 혹은 숫자로만 이루어져야 합니다.', () => {
         this.username.focus();
-      });
-      return null;
-    }
-
-    if (values.password.length === 0) {
-      this.props.alertModal('알림', '비밀번호를 입력해주세요.', () => {
-        this.password.focus();
-      });
-      return null;
-    }
-
-    if (values.password !== values.password2) {
-      this.props.alertModal('알림', '비밀번호를 확인해주세요.', () => {
-        this.password2.focus();
       });
       return null;
     }
@@ -128,14 +114,6 @@ const SignUpForm = connectModals(React.createClass({
           {this.renderInput('username', 'ID')}
         </div>
         <div className="signup-form-group">
-          <label className="signup-form-label" htmlFor="signup-password-input">비밀번호</label>
-          {this.renderInput('password', '******', 'password')}
-        </div>
-        <div className="signup-form-group">
-          <label className="signup-form-label" htmlFor="signup-password2-input">비밀번호 확인</label>
-          {this.renderInput('password2', '******', 'password')}
-        </div>
-        <div className="signup-form-group">
           <label className="signup-form-label" htmlFor="signup-name-input">이름</label>
           {this.renderInput('name', '홍길동')}
         </div>
@@ -154,6 +132,9 @@ const SignUpForm = connectModals(React.createClass({
         <div className="signup-form-group">
           <label className="signup-form-label" htmlFor="signup-email-input">이메일</label>
           {this.renderInput('email', 'example@example.com', 'email')}
+          <div className="signup-form-description">
+            가입 승인 후 이메일로 임시 비밀번호가 발송됩니다.
+          </div>
         </div>
         <div id="signup-button-container">
           <button id="signup-button" onClick={this.handleSignUp}>가입 신청</button>

--- a/stylesheets/login.styl
+++ b/stylesheets/login.styl
@@ -77,7 +77,7 @@
 #signup-box-container
   position absolute
   width 700px
-  height 510px
+  height 460px
   top 0
   bottom 0
   left 0
@@ -92,7 +92,7 @@
 #signup-box
   background-color background-color
   width 700px
-  height 470px
+  height 420px
   padding 15px
 #signup-box-header
   margin-bottom 15px
@@ -116,6 +116,8 @@
   color input-text-color
   vertical-align middle
   border 1px solid box-border-color
+.signup-form-description
+  margin-left 200px
 #signup-button-container
   padding-top 10px
   text-align center

--- a/stylesheets/login.styl
+++ b/stylesheets/login.styl
@@ -74,6 +74,7 @@
   font-size 16px
 .login-box-footer-link
   color text-color
+  margin 0 30px
 #signup-box-container
   position absolute
   width 700px


### PR DESCRIPTION
인증 정보를 id.snucse.org의 정보로 일원화하기로 하여 가입 신청 시 비밀번호를 받지 않도록 하고, 로그인 폼에 id.snucse.org의 비밀번호 찾기 페이지로 가는 링크를 추가했습니다.
(현재 코드 기준으로 서버의 가입 API에서 password가 required parameter이기 때문에 동작하지 않습니다. 리뷰를 위해 우선 클라이언트 먼저 작업했습니다.)