### PR TITLE
fix profile id router

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,20 +44,16 @@ const store = createStore(
   applyMiddleware(middleware)
 );
 
-const ProfileIdRoute = ({match}) => (
-  <Switch>
-    <Route path={`${match.url}/admin`} component={ProfileAdmin}/>
-    <Route path={`${match.url}/transfer_admin`} component={ProfileAdminTransfer}/>
-    <Route path={`${match.url}/write`} component={ArticleWrite}/>
-  </Switch>
-);
 const ProfileRoute = ({match}) => (
   <Switch>
     <Route exact path={`${match.url}`} component={ProfileList}/>
     <Route path={`${match.url}/new`} component={ProfileMake}/>
-    <Route path={`${match.url}/:id`} component={ProfileIdRoute}/>
+    <Route path={`${match.url}/:id/admin`} component={ProfileAdmin}/>
+    <Route path={`${match.url}/:id/transfer_admin`} component={ProfileAdminTransfer}/>
+    <Route path={`${match.url}/:id/write`} component={ArticleWrite}/>
   </Switch>
 );
+
 const MenuRoute = () => (
   <Menu>
     <Switch>


### PR DESCRIPTION
자식 컴포넌트에 부모의 match 정보가 가지 않아서 id 정보가 사라집니다.
일단 곧장 가리키어 id가 들어가게끔 조치했습니다.